### PR TITLE
Add comprehensive test suite (225 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,11 @@ Thumbs.db
 # Docker
 *.dockerfile.swp
 
-# Test files
-test_*.py
-check_*.py
+# Test files (scratch/debug scripts at root level)
+/test_*.py
+/check_*.py
+/backend/test_*.py
+/backend/check_*.py
 
 # Temporary files
 *.tmp

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,49 @@
+"""Shared fixtures for all tests."""
+
+import pytest
+import pandas as pd
+import numpy as np
+import tempfile
+import os
+
+
+@pytest.fixture
+def sample_ohlcv_df():
+    """Generate a realistic OHLCV DataFrame for strategy testing."""
+    np.random.seed(42)
+    n = 100
+    base_price = 24000
+    returns = np.random.normal(0.0001, 0.005, n)
+    prices = base_price * np.exp(np.cumsum(returns))
+
+    df = pd.DataFrame({
+        'open': prices * (1 + np.random.uniform(-0.002, 0.002, n)),
+        'high': prices * (1 + np.abs(np.random.uniform(0, 0.01, n))),
+        'low': prices * (1 - np.abs(np.random.uniform(0, 0.01, n))),
+        'close': prices,
+        'volume': np.random.randint(100000, 1000000, n),
+    })
+    df.index = pd.date_range('2025-01-01', periods=n, freq='5min')
+    return df
+
+
+@pytest.fixture
+def small_ohlcv_df():
+    """A small DataFrame with insufficient data for indicators."""
+    return pd.DataFrame({
+        'open': [100, 101],
+        'high': [102, 103],
+        'low': [99, 100],
+        'close': [101, 102],
+        'volume': [1000, 1100],
+    })
+
+
+@pytest.fixture
+def tmp_json_file():
+    """Provide a temporary JSON file path, cleaned up after test."""
+    fd, path = tempfile.mkstemp(suffix='.json')
+    os.close(fd)
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)

--- a/backend/tests/test_backtester.py
+++ b/backend/tests/test_backtester.py
@@ -1,0 +1,151 @@
+"""Tests for Backtester - metrics calculation and mock data generation."""
+
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import MagicMock, patch
+from app.strategies.backtester import Backtester
+
+
+class TestBacktesterMetrics:
+    """Test the _calculate_metrics method directly (no external deps)."""
+
+    def _make_backtester(self):
+        """Create a Backtester with mocked dependencies."""
+        mock_fetcher = MagicMock()
+        mock_strategy = MagicMock()
+        bt = Backtester(data_fetcher=mock_fetcher, strategy_engine=mock_strategy)
+        return bt
+
+    def test_no_trades(self):
+        bt = self._make_backtester()
+        bt.trades = []
+        metrics = bt._calculate_metrics(100000, 100000)
+        assert metrics['total_return_pct'] == 0
+        assert metrics['win_rate'] == 0
+        assert metrics['profit_factor'] == 0
+
+    def test_all_wins(self):
+        bt = self._make_backtester()
+        bt.trades = [
+            {'pnl': 100, 'pnl_pct': 10},
+            {'pnl': 200, 'pnl_pct': 20},
+        ]
+        metrics = bt._calculate_metrics(100000, 100300)
+        assert metrics['win_rate'] == 100.0
+        assert metrics['avg_win'] == 150.0
+        assert metrics['avg_loss'] == 0
+
+    def test_all_losses(self):
+        bt = self._make_backtester()
+        bt.trades = [
+            {'pnl': -100, 'pnl_pct': -10},
+            {'pnl': -200, 'pnl_pct': -20},
+        ]
+        metrics = bt._calculate_metrics(100000, 99700)
+        assert metrics['win_rate'] == 0.0
+        assert metrics['avg_loss'] == -150.0
+        assert metrics['profit_factor'] == 0
+
+    def test_mixed_trades(self):
+        bt = self._make_backtester()
+        bt.trades = [
+            {'pnl': 300, 'pnl_pct': 30},
+            {'pnl': -100, 'pnl_pct': -10},
+        ]
+        metrics = bt._calculate_metrics(100000, 100200)
+        assert metrics['win_rate'] == 50.0
+        assert metrics['avg_win'] == 300.0
+        assert metrics['avg_loss'] == -100.0
+        assert metrics['profit_factor'] == 3.0  # 300 / 100
+
+    def test_max_drawdown(self):
+        bt = self._make_backtester()
+        bt.trades = [
+            {'pnl': 1000, 'pnl_pct': 1},
+            {'pnl': -3000, 'pnl_pct': -3},
+            {'pnl': 500, 'pnl_pct': 0.5},
+        ]
+        metrics = bt._calculate_metrics(100000, 98500)
+        # Peak: 101000, trough: 98000, drawdown = (101000-98000)/101000 * 100 ≈ 2.97%
+        assert metrics['max_drawdown_pct'] > 0
+
+    def test_return_pct(self):
+        bt = self._make_backtester()
+        bt.trades = [{'pnl': 10000, 'pnl_pct': 10}]
+        metrics = bt._calculate_metrics(100000, 110000)
+        assert metrics['total_return_pct'] == 10.0
+
+
+class TestGenerateMockData:
+    """Test mock data generation for backtesting."""
+
+    def _make_backtester(self):
+        mock_fetcher = MagicMock()
+        mock_strategy = MagicMock()
+        return Backtester(data_fetcher=mock_fetcher, strategy_engine=mock_strategy)
+
+    def test_generates_dataframe(self):
+        bt = self._make_backtester()
+        df = bt._generate_mock_data("2025-01-01", "2025-01-05", "1minute")
+        assert df is not None
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0
+
+    def test_has_ohlcv_columns(self):
+        bt = self._make_backtester()
+        df = bt._generate_mock_data("2025-01-01", "2025-01-05", "1minute")
+        for col in ['open', 'high', 'low', 'close', 'volume']:
+            assert col in df.columns
+
+    def test_max_500_candles(self):
+        bt = self._make_backtester()
+        df = bt._generate_mock_data("2020-01-01", "2025-01-01", "1minute")
+        assert len(df) <= 500
+
+    def test_invalid_dates_returns_none(self):
+        bt = self._make_backtester()
+        df = bt._generate_mock_data("2025-01-05", "2025-01-01", "1minute")
+        # End before start should produce empty or None
+        assert df is None or len(df) == 0
+
+
+class TestRunBacktest:
+    """Test the full backtest pipeline with mocked data fetcher."""
+
+    def test_backtest_with_mock_data(self):
+        """Run a minimal backtest using mock data generation."""
+        mock_fetcher = MagicMock()
+        mock_fetcher.get_historical_data.return_value = None  # Force mock data
+
+        from app.strategies.strategy import StrategyEngine
+        real_strategy = StrategyEngine()
+
+        bt = Backtester(data_fetcher=mock_fetcher, strategy_engine=real_strategy)
+        result = bt.run_backtest(
+            symbol="NSE_INDEX|Nifty 50",
+            from_date="2025-01-01",
+            to_date="2025-01-10",
+            initial_capital=100000,
+            interval="1minute"
+        )
+
+        assert 'initial_capital' in result
+        assert 'final_capital' in result
+        assert 'total_trades' in result
+        assert 'trades' in result
+        assert 'metrics' in result
+        assert result['initial_capital'] == 100000
+
+    def test_backtest_returns_error_on_no_data(self):
+        """When both real and mock data fail, return error."""
+        mock_fetcher = MagicMock()
+        mock_fetcher.get_historical_data.side_effect = Exception("API down")
+
+        mock_strategy = MagicMock()
+        bt = Backtester(data_fetcher=mock_fetcher, strategy_engine=mock_strategy)
+
+        # Patch _generate_mock_data to also fail
+        with patch.object(bt, '_generate_mock_data', return_value=None):
+            result = bt.run_backtest("SYM", "2025-01-01", "2025-01-02")
+            assert 'error' in result

--- a/backend/tests/test_greeks.py
+++ b/backend/tests/test_greeks.py
@@ -1,0 +1,269 @@
+"""Tests for Black-Scholes Greeks Calculator."""
+
+import pytest
+import numpy as np
+from scipy.stats import norm
+from app.core.greeks import GreeksCalculator
+
+
+class TestGreeksCalculatorD1D2:
+    """Test d1 and d2 helper calculations."""
+
+    def setup_method(self):
+        self.calc = GreeksCalculator(risk_free_rate=0.06)
+
+    def test_d1_basic(self):
+        """d1 for ATM option with known inputs."""
+        S, K, T, sigma = 100, 100, 1.0, 0.20
+        d1 = self.calc.d1(S, K, T, sigma)
+        # manual: (ln(1) + (0.06 + 0.02)*1) / (0.20*1) = 0.08/0.20 = 0.4
+        assert pytest.approx(d1, rel=1e-6) == 0.4
+
+    def test_d2_basic(self):
+        """d2 = d1 - sigma*sqrt(T)."""
+        S, K, T, sigma = 100, 100, 1.0, 0.20
+        d2 = self.calc.d2(S, K, T, sigma)
+        assert pytest.approx(d2, rel=1e-6) == 0.4 - 0.20
+
+    def test_d1_zero_time(self):
+        """d1 returns 0 when T <= 0."""
+        assert self.calc.d1(100, 100, 0, 0.2) == 0
+        assert self.calc.d1(100, 100, -1, 0.2) == 0
+
+    def test_d1_zero_sigma(self):
+        """d1 returns 0 when sigma <= 0."""
+        assert self.calc.d1(100, 100, 1, 0) == 0
+        assert self.calc.d1(100, 100, 1, -0.1) == 0
+
+
+class TestCalculateGreeks:
+    """Test the main calculate_greeks method."""
+
+    def setup_method(self):
+        self.calc = GreeksCalculator(risk_free_rate=0.06)
+
+    def test_ce_delta_atm(self):
+        """ATM call delta should be close to 0.5."""
+        greeks = self.calc.calculate_greeks(100, 100, 1.0, 0.20, 'CE')
+        assert 0.45 < greeks['delta'] < 0.75
+
+    def test_pe_delta_atm(self):
+        """ATM put delta should be close to -0.5."""
+        greeks = self.calc.calculate_greeks(100, 100, 1.0, 0.20, 'PE')
+        assert -0.75 < greeks['delta'] < -0.25
+
+    def test_ce_delta_range(self):
+        """Call delta must be between 0 and 1."""
+        for S in [80, 100, 120]:
+            greeks = self.calc.calculate_greeks(S, 100, 0.5, 0.25, 'CE')
+            assert 0 <= greeks['delta'] <= 1
+
+    def test_pe_delta_range(self):
+        """Put delta must be between -1 and 0."""
+        for S in [80, 100, 120]:
+            greeks = self.calc.calculate_greeks(S, 100, 0.5, 0.25, 'PE')
+            assert -1 <= greeks['delta'] <= 0
+
+    def test_gamma_positive(self):
+        """Gamma should always be positive for both CE and PE."""
+        for opt_type in ['CE', 'PE']:
+            greeks = self.calc.calculate_greeks(100, 100, 0.5, 0.25, opt_type)
+            assert greeks['gamma'] >= 0
+
+    def test_gamma_same_for_call_and_put(self):
+        """Gamma is the same for call and put at same strike."""
+        ce = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'CE')
+        pe = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'PE')
+        assert pytest.approx(ce['gamma'], abs=1e-6) == pe['gamma']
+
+    def test_theta_negative_for_long(self):
+        """Theta should typically be negative (time decay) for CE."""
+        greeks = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'CE')
+        assert greeks['theta'] < 0
+
+    def test_vega_positive(self):
+        """Vega should be positive."""
+        greeks = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'CE')
+        assert greeks['vega'] > 0
+
+    def test_vega_same_for_call_and_put(self):
+        """Vega is the same for call and put."""
+        ce = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'CE')
+        pe = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'PE')
+        assert pytest.approx(ce['vega'], abs=1e-4) == pe['vega']
+
+    def test_rho_ce_positive(self):
+        """Call rho should be positive."""
+        greeks = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'CE')
+        assert greeks['rho'] > 0
+
+    def test_rho_pe_negative(self):
+        """Put rho should be negative."""
+        greeks = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'PE')
+        assert greeks['rho'] < 0
+
+    def test_zero_time_returns_zeros(self):
+        """When T=0, all greeks should be zero."""
+        greeks = self.calc.calculate_greeks(100, 100, 0, 0.25, 'CE')
+        assert greeks == {'delta': 0, 'gamma': 0, 'theta': 0, 'vega': 0, 'rho': 0, 'quality_score': 0}
+
+    def test_zero_sigma_returns_zeros(self):
+        """When sigma=0, all greeks should be zero."""
+        greeks = self.calc.calculate_greeks(100, 100, 0.5, 0, 'CE')
+        assert greeks == {'delta': 0, 'gamma': 0, 'theta': 0, 'vega': 0, 'rho': 0, 'quality_score': 0}
+
+    def test_deep_itm_call_delta_near_1(self):
+        """Deep ITM call should have delta near 1."""
+        greeks = self.calc.calculate_greeks(150, 100, 0.5, 0.25, 'CE')
+        assert greeks['delta'] > 0.9
+
+    def test_deep_otm_call_delta_near_0(self):
+        """Deep OTM call should have delta near 0."""
+        greeks = self.calc.calculate_greeks(50, 100, 0.5, 0.25, 'CE')
+        assert greeks['delta'] < 0.1
+
+    def test_custom_risk_free_rate(self):
+        """Overriding risk_free_rate parameter should be used - higher rate -> higher call price."""
+        p1 = self.calc.black_scholes_price(100, 100, 1.0, 0.20, 'CE', risk_free_rate=0.01)
+        p2 = self.calc.black_scholes_price(100, 100, 1.0, 0.20, 'CE', risk_free_rate=0.10)
+        # Higher risk-free rate -> higher call price
+        assert p2 > p1
+
+    def test_quality_score_in_range(self):
+        """Quality score should be between 0 and 100."""
+        greeks = self.calc.calculate_greeks(100, 100, 0.05, 0.25, 'CE')
+        assert 0 <= greeks['quality_score'] <= 100
+
+    def test_put_call_parity_delta(self):
+        """Put-call parity: CE delta - PE delta ≈ 1."""
+        ce = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'CE')
+        pe = self.calc.calculate_greeks(100, 100, 0.5, 0.25, 'PE')
+        assert pytest.approx(ce['delta'] - pe['delta'], abs=0.01) == 1.0
+
+
+class TestBlackScholesPrice:
+    """Test option pricing."""
+
+    def setup_method(self):
+        self.calc = GreeksCalculator(risk_free_rate=0.06)
+
+    def test_call_price_positive(self):
+        price = self.calc.black_scholes_price(100, 100, 1.0, 0.20, 'CE')
+        assert price > 0
+
+    def test_put_price_positive(self):
+        price = self.calc.black_scholes_price(100, 100, 1.0, 0.20, 'PE')
+        assert price > 0
+
+    def test_put_call_parity(self):
+        """C - P = S - K*exp(-rT)."""
+        S, K, T, sigma, r = 100, 100, 1.0, 0.20, 0.06
+        call = self.calc.black_scholes_price(S, K, T, sigma, 'CE')
+        put = self.calc.black_scholes_price(S, K, T, sigma, 'PE')
+        expected = S - K * np.exp(-r * T)
+        assert pytest.approx(call - put, abs=0.01) == expected
+
+    def test_zero_time_call_intrinsic(self):
+        """At expiry, call price = max(0, S-K)."""
+        assert self.calc.black_scholes_price(110, 100, 0, 0.25, 'CE') == 10
+        assert self.calc.black_scholes_price(90, 100, 0, 0.25, 'CE') == 0
+
+    def test_zero_time_put_intrinsic(self):
+        """At expiry, put price = max(0, K-S)."""
+        assert self.calc.black_scholes_price(90, 100, 0, 0.25, 'PE') == 10
+        assert self.calc.black_scholes_price(110, 100, 0, 0.25, 'PE') == 0
+
+    def test_call_increases_with_spot(self):
+        """Call price increases as spot increases."""
+        p1 = self.calc.black_scholes_price(90, 100, 0.5, 0.25, 'CE')
+        p2 = self.calc.black_scholes_price(100, 100, 0.5, 0.25, 'CE')
+        p3 = self.calc.black_scholes_price(110, 100, 0.5, 0.25, 'CE')
+        assert p1 < p2 < p3
+
+    def test_put_increases_with_lower_spot(self):
+        """Put price increases as spot decreases."""
+        p1 = self.calc.black_scholes_price(110, 100, 0.5, 0.25, 'PE')
+        p2 = self.calc.black_scholes_price(100, 100, 0.5, 0.25, 'PE')
+        p3 = self.calc.black_scholes_price(90, 100, 0.5, 0.25, 'PE')
+        assert p1 < p2 < p3
+
+
+class TestImpliedVolatility:
+    """Test IV calculation using Newton-Raphson."""
+
+    def setup_method(self):
+        self.calc = GreeksCalculator(risk_free_rate=0.06)
+
+    def test_iv_round_trip(self):
+        """Calculate price from known sigma, then recover sigma via IV."""
+        sigma = 0.25
+        S, K, T = 100, 100, 0.5
+        price = self.calc.black_scholes_price(S, K, T, sigma, 'CE')
+        recovered = self.calc.implied_volatility(price, S, K, T, 'CE')
+        assert pytest.approx(recovered, abs=0.01) == sigma
+
+    def test_iv_round_trip_put(self):
+        """IV round-trip for put option."""
+        sigma = 0.30
+        S, K, T = 100, 100, 0.5
+        price = self.calc.black_scholes_price(S, K, T, sigma, 'PE')
+        recovered = self.calc.implied_volatility(price, S, K, T, 'PE')
+        assert pytest.approx(recovered, abs=0.01) == sigma
+
+    def test_iv_below_intrinsic_returns_low(self):
+        """When market price is at or below intrinsic, IV should be minimal."""
+        iv = self.calc.implied_volatility(5, 105, 100, 0.5, 'CE')
+        assert iv <= 0.05
+
+    def test_iv_positive(self):
+        """IV should always be positive."""
+        iv = self.calc.implied_volatility(10, 100, 100, 0.5, 'CE')
+        assert iv > 0
+
+
+class TestQualityScore:
+    """Test the quality scoring logic."""
+
+    def setup_method(self):
+        self.calc = GreeksCalculator(risk_free_rate=0.06)
+
+    def test_atm_high_score(self):
+        """ATM option with reasonable time and vol should score well."""
+        # T=20/365 (20 days), sigma=0.20, ATM
+        greeks = self.calc.calculate_greeks(100, 100, 20 / 365, 0.20, 'CE')
+        assert greeks['quality_score'] >= 60
+
+    def test_deep_otm_low_score(self):
+        """Deep OTM option should score lower on moneyness."""
+        greeks = self.calc.calculate_greeks(100, 150, 20 / 365, 0.20, 'CE')
+        assert greeks['quality_score'] < 80
+
+    def test_score_clamped_0_100(self):
+        """Score should always be between 0 and 100."""
+        for S in [50, 100, 200]:
+            for T in [1 / 365, 10 / 365, 60 / 365, 200 / 365]:
+                for sigma in [0.01, 0.20, 0.50, 2.0]:
+                    greeks = self.calc.calculate_greeks(S, 100, T, sigma, 'CE')
+                    assert 0 <= greeks['quality_score'] <= 100
+
+
+class TestTimeToExpiry:
+    """Test time_to_expiry helper."""
+
+    def setup_method(self):
+        self.calc = GreeksCalculator()
+
+    def test_future_date_positive(self):
+        """A future expiry date should return positive T."""
+        T = self.calc.time_to_expiry("2030-12-31")
+        assert T > 0
+
+    def test_past_date_returns_minimum(self):
+        """A past expiry date should return the minimum (0.0001)."""
+        T = self.calc.time_to_expiry("2020-01-01")
+        assert T == 0.0001
+
+    def test_invalid_date_returns_zero(self):
+        """An invalid date string should return 0."""
+        T = self.calc.time_to_expiry("not-a-date")
+        assert T == 0

--- a/backend/tests/test_greeks_validator.py
+++ b/backend/tests/test_greeks_validator.py
@@ -1,0 +1,214 @@
+"""Tests for Greeks Quality Validator."""
+
+import pytest
+from app.core.greeks_validator import GreeksValidator, validate_greeks_quality
+
+
+class TestValidateDelta:
+    """Test delta validation."""
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_valid_ce_delta(self):
+        self.v._validate_delta(0.5, 'CE', 100, 100)
+        assert len(self.v.validation_errors) == 0
+
+    def test_ce_delta_out_of_range(self):
+        self.v._validate_delta(1.5, 'CE', 100, 100)
+        assert len(self.v.validation_errors) == 1
+
+    def test_ce_delta_negative_error(self):
+        self.v._validate_delta(-0.1, 'CE', 100, 100)
+        assert len(self.v.validation_errors) == 1
+
+    def test_valid_pe_delta(self):
+        self.v._validate_delta(-0.5, 'PE', 100, 100)
+        assert len(self.v.validation_errors) == 0
+
+    def test_pe_delta_out_of_range(self):
+        self.v._validate_delta(0.5, 'PE', 100, 100)
+        assert len(self.v.validation_errors) == 1
+
+    def test_itm_ce_low_delta_warning(self):
+        """ITM CE (S>K) with low delta should warn."""
+        self.v._validate_delta(0.3, 'CE', 110, 100)
+        assert len(self.v.warnings) == 1
+
+    def test_itm_pe_high_delta_warning(self):
+        """ITM PE (S<K) with high delta should warn."""
+        self.v._validate_delta(-0.3, 'PE', 90, 100)
+        assert len(self.v.warnings) == 1
+
+
+class TestValidateGamma:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_positive_gamma(self):
+        self.v._validate_gamma(0.005)
+        assert len(self.v.validation_errors) == 0
+
+    def test_negative_gamma_error(self):
+        self.v._validate_gamma(-0.001)
+        assert len(self.v.validation_errors) == 1
+
+    def test_very_high_gamma_warning(self):
+        self.v._validate_gamma(0.02)
+        assert len(self.v.warnings) == 1
+
+
+class TestValidateTheta:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_negative_theta_ok(self):
+        self.v._validate_theta(-5.0, 'CE')
+        assert len(self.v.validation_errors) == 0
+        assert len(self.v.warnings) == 0
+
+    def test_positive_ce_theta_warning(self):
+        self.v._validate_theta(1.0, 'CE')
+        assert len(self.v.warnings) == 1
+
+    def test_very_high_theta_warning(self):
+        self.v._validate_theta(-60.0, 'CE')
+        assert len(self.v.warnings) == 1
+
+
+class TestValidateVega:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_positive_vega_ok(self):
+        self.v._validate_vega(5.0)
+        assert len(self.v.validation_errors) == 0
+
+    def test_negative_vega_error(self):
+        self.v._validate_vega(-1.0)
+        assert len(self.v.validation_errors) == 1
+
+    def test_very_high_vega_warning(self):
+        self.v._validate_vega(150.0)
+        assert len(self.v.warnings) == 1
+
+
+class TestValidateRho:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_positive_ce_rho_ok(self):
+        self.v._validate_rho(2.0, 'CE')
+        assert len(self.v.warnings) == 0
+
+    def test_negative_ce_rho_warning(self):
+        self.v._validate_rho(-1.0, 'CE')
+        assert len(self.v.warnings) == 1
+
+    def test_positive_pe_rho_warning(self):
+        self.v._validate_rho(1.0, 'PE')
+        assert len(self.v.warnings) == 1
+
+
+class TestValidateIV:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_reasonable_iv(self):
+        self.v._validate_iv(0.25, 10, 100, 100, 0.5)
+        assert len(self.v.validation_errors) == 0
+        assert len(self.v.warnings) == 0
+
+    def test_zero_iv_error(self):
+        self.v._validate_iv(0, 10, 100, 100, 0.5)
+        assert len(self.v.validation_errors) == 1
+
+    def test_very_low_iv_warning(self):
+        self.v._validate_iv(0.03, 10, 100, 100, 0.5)
+        assert len(self.v.warnings) == 1
+
+    def test_very_high_iv_warning(self):
+        self.v._validate_iv(1.5, 10, 100, 100, 0.5)
+        assert len(self.v.warnings) == 1
+
+
+class TestValidateRelationships:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_high_gamma_low_theta_warning(self):
+        self.v._validate_relationships(0.5, 0.005, -0.5, 5.0, 0.1)
+        assert len(self.v.warnings) == 1
+
+    def test_deep_itm_high_gamma_warning(self):
+        self.v._validate_relationships(0.95, 0.006, -5.0, 5.0, 0.1)
+        assert any("Deep ITM/OTM" in w for w in self.v.warnings)
+
+
+class TestQualityScore:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_perfect_score(self):
+        """No errors or warnings -> 100."""
+        assert self.v._calculate_quality_score() == 100
+
+    def test_score_with_errors(self):
+        self.v.validation_errors = ["err1"]
+        assert self.v._calculate_quality_score() == 70
+
+    def test_score_with_warnings(self):
+        self.v.warnings = ["warn1", "warn2"]
+        assert self.v._calculate_quality_score() == 80
+
+    def test_score_floor_at_zero(self):
+        self.v.validation_errors = ["e1", "e2", "e3", "e4"]
+        assert self.v._calculate_quality_score() == 0
+
+
+class TestQualitySummary:
+
+    def setup_method(self):
+        self.v = GreeksValidator()
+
+    def test_excellent(self):
+        assert self.v._get_quality_summary(95) == "Excellent"
+
+    def test_good(self):
+        assert self.v._get_quality_summary(75) == "Good"
+
+    def test_fair(self):
+        assert self.v._get_quality_summary(55) == "Fair"
+
+    def test_poor(self):
+        assert self.v._get_quality_summary(30) == "Poor"
+
+
+class TestFullValidation:
+    """Test the full validate_greeks method end-to-end."""
+
+    def test_valid_greeks(self):
+        greeks_data = {
+            'delta': 0.5, 'gamma': 0.003, 'theta': -5.0,
+            'vega': 10.0, 'rho': 2.0, 'iv': 0.25
+        }
+        result = validate_greeks_quality(greeks_data, 100, 100, 0.1, 'CE', 10)
+        assert result['is_valid'] is True
+        assert result['quality_score'] > 0
+        assert 'summary' in result
+
+    def test_invalid_greeks(self):
+        greeks_data = {
+            'delta': 1.5, 'gamma': -0.01, 'theta': -5.0,
+            'vega': -1.0, 'rho': 2.0, 'iv': 0
+        }
+        result = validate_greeks_quality(greeks_data, 100, 100, 0.1, 'CE', 10)
+        assert result['is_valid'] is False
+        assert len(result['errors']) > 0

--- a/backend/tests/test_json_utils.py
+++ b/backend/tests/test_json_utils.py
@@ -1,0 +1,64 @@
+"""Tests for JSON utility functions."""
+
+import pytest
+import numpy as np
+from app.utils.json_utils import convert_numpy_types
+
+
+class TestConvertNumpyTypes:
+
+    def test_int64(self):
+        assert convert_numpy_types(np.int64(42)) == 42
+        assert isinstance(convert_numpy_types(np.int64(42)), int)
+
+    def test_int32(self):
+        assert convert_numpy_types(np.int32(10)) == 10
+        assert isinstance(convert_numpy_types(np.int32(10)), int)
+
+    def test_float64(self):
+        result = convert_numpy_types(np.float64(3.14))
+        assert result == 3.14
+        assert isinstance(result, float)
+
+    def test_float32(self):
+        result = convert_numpy_types(np.float32(2.5))
+        assert isinstance(result, float)
+
+    def test_bool_(self):
+        assert convert_numpy_types(np.bool_(True)) is True
+        assert isinstance(convert_numpy_types(np.bool_(True)), bool)
+
+    def test_ndarray(self):
+        arr = np.array([1, 2, 3])
+        result = convert_numpy_types(arr)
+        assert result == [1, 2, 3]
+        assert isinstance(result, list)
+
+    def test_dict_recursive(self):
+        data = {'a': np.int64(1), 'b': np.float64(2.5), 'c': 'hello'}
+        result = convert_numpy_types(data)
+        assert result == {'a': 1, 'b': 2.5, 'c': 'hello'}
+        assert isinstance(result['a'], int)
+        assert isinstance(result['b'], float)
+
+    def test_list_recursive(self):
+        data = [np.int64(1), np.float64(2.5), 'hello']
+        result = convert_numpy_types(data)
+        assert result == [1, 2.5, 'hello']
+
+    def test_nested_dict_in_list(self):
+        data = [{'val': np.int64(42)}]
+        result = convert_numpy_types(data)
+        assert result == [{'val': 42}]
+
+    def test_plain_python_types_unchanged(self):
+        assert convert_numpy_types(42) == 42
+        assert convert_numpy_types(3.14) == 3.14
+        assert convert_numpy_types("hello") == "hello"
+        assert convert_numpy_types(None) is None
+        assert convert_numpy_types(True) is True
+
+    def test_2d_ndarray(self):
+        arr = np.array([[1, 2], [3, 4]])
+        result = convert_numpy_types(arr)
+        assert result == [[1, 2], [3, 4]]

--- a/backend/tests/test_paper_trading.py
+++ b/backend/tests/test_paper_trading.py
@@ -1,0 +1,178 @@
+"""Tests for Paper Trading Manager."""
+
+import pytest
+import os
+from app.managers.paper_trading import PaperTradingManager
+
+
+class TestPaperTradingInit:
+
+    def test_default_balance(self, tmp_json_file):
+        # Remove the temp file so PaperTradingManager creates defaults
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        assert pm.get_balance() == 100000.0
+
+    def test_default_data_structure(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        assert pm.data['positions'] == []
+        assert pm.data['orders'] == []
+
+
+class TestAddFunds:
+
+    def test_add_positive_amount(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        new_balance = pm.add_funds(5000)
+        assert new_balance == 105000.0
+
+    def test_add_zero_rejected(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        new_balance = pm.add_funds(0)
+        assert new_balance == 100000.0
+
+    def test_add_negative_rejected(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        new_balance = pm.add_funds(-500)
+        assert new_balance == 100000.0
+
+    def test_add_invalid_type(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        new_balance = pm.add_funds("abc")
+        assert new_balance == 100000.0
+
+
+class TestPlaceOrder:
+
+    def test_buy_order(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        order_id = pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        assert order_id is not None
+        assert pm.get_balance() == 99000.0  # 100000 - 10*100
+
+    def test_buy_insufficient_funds(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        order_id = pm.place_order("NSE_FO|12345", 10000, "BUY", 100.0)
+        assert order_id is None  # 10000 * 100 = 1M > 100K
+
+    def test_sell_order(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        order_id = pm.place_order("NSE_FO|12345", 5, "SELL", 120.0)
+        assert order_id is not None
+        # Balance: 100000 - 1000 + 600 = 99600
+        assert pm.get_balance() == 99600.0
+
+    def test_sell_without_position(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        order_id = pm.place_order("NSE_FO|12345", 5, "SELL", 120.0)
+        assert order_id is None
+
+    def test_sell_more_than_held(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 5, "BUY", 100.0)
+        order_id = pm.place_order("NSE_FO|12345", 10, "SELL", 120.0)
+        assert order_id is None
+
+
+class TestPositionTracking:
+
+    def test_position_created_on_buy(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        positions = pm.get_positions()
+        assert len(positions) == 1
+        assert positions[0]['quantity'] == 10
+        assert positions[0]['average_price'] == 100.0
+
+    def test_position_averages_on_add(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 200.0)
+        positions = pm.get_positions()
+        assert positions[0]['quantity'] == 20
+        assert positions[0]['average_price'] == 150.0  # (10*100 + 10*200) / 20
+
+    def test_position_removed_on_full_sell(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pm.place_order("NSE_FO|12345", 10, "SELL", 120.0)
+        positions = pm.get_positions()
+        assert len(positions) == 0
+
+    def test_partial_sell(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pm.place_order("NSE_FO|12345", 3, "SELL", 120.0)
+        positions = pm.get_positions()
+        assert len(positions) == 1
+        assert positions[0]['quantity'] == 7
+
+
+class TestPnL:
+
+    def test_unrealized_pnl(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pnl = pm.get_pnl({"NSE_FO|12345": 110.0})
+        assert pnl == 100.0  # (110-100) * 10
+
+    def test_pnl_no_prices(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        assert pm.get_pnl(None) == 0.0
+        assert pm.get_pnl({}) == 0.0
+
+    def test_realized_pnl_after_sell(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pm.place_order("NSE_FO|12345", 10, "SELL", 120.0)
+        assert pm.get_daily_realized_pnl() == 200.0  # (120-100)*10
+
+    def test_closed_trades_recorded(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pm.place_order("NSE_FO|12345", 10, "SELL", 120.0)
+        closed = pm.get_closed_trades()
+        assert len(closed) == 1
+        assert closed[0]['pnl'] == 200.0
+
+    def test_total_pnl(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm = PaperTradingManager(data_file=tmp_json_file)
+        pm.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+        pm.place_order("NSE_FO|12345", 5, "SELL", 120.0)
+        # Realized: (120-100)*5 = 100
+        # Unrealized: (110-100)*5 = 50
+        total = pm.get_total_pnl({"NSE_FO|12345": 110.0})
+        assert total == 150.0
+
+
+class TestPersistence:
+
+    def test_save_and_load(self, tmp_json_file):
+        os.unlink(tmp_json_file)
+        pm1 = PaperTradingManager(data_file=tmp_json_file)
+        pm1.place_order("NSE_FO|12345", 10, "BUY", 100.0)
+
+        pm2 = PaperTradingManager(data_file=tmp_json_file)
+        assert pm2.get_balance() == pm1.get_balance()
+        assert len(pm2.get_positions()) == 1

--- a/backend/tests/test_pcr_calculator.py
+++ b/backend/tests/test_pcr_calculator.py
@@ -1,0 +1,227 @@
+"""Tests for Put-Call Ratio Calculator."""
+
+import pytest
+from app.core.pcr_calculator import PCRCalculator
+
+
+class TestCalculatePCR:
+    """Test basic PCR calculation."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_basic_pcr(self):
+        assert self.calc.calculate_pcr(1500, 1000) == 1.5
+
+    def test_pcr_equal_oi(self):
+        assert self.calc.calculate_pcr(1000, 1000) == 1.0
+
+    def test_pcr_bullish(self):
+        """More calls than puts -> PCR < 1."""
+        pcr = self.calc.calculate_pcr(500, 1000)
+        assert pcr == 0.5
+
+    def test_pcr_zero_call_oi(self):
+        """Zero call OI should return None."""
+        assert self.calc.calculate_pcr(1000, 0) is None
+
+    def test_pcr_negative_call_oi(self):
+        """Negative call OI should return None."""
+        assert self.calc.calculate_pcr(1000, -100) is None
+
+    def test_pcr_rounded(self):
+        """PCR should be rounded to 4 decimals."""
+        pcr = self.calc.calculate_pcr(1000, 3000)
+        assert pcr == round(1000 / 3000, 4)
+
+
+class TestCalculatePCRFromOptions:
+    """Test PCR from options list."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_from_options_basic(self):
+        options = [
+            {'option_type': 'PE', 'oi': 500},
+            {'option_type': 'PE', 'oi': 500},
+            {'option_type': 'CE', 'oi': 1000},
+        ]
+        assert self.calc.calculate_pcr_from_options(options) == 1.0
+
+    def test_from_options_empty(self):
+        assert self.calc.calculate_pcr_from_options([]) is None
+
+    def test_from_options_no_calls(self):
+        """Only puts, no calls -> None (division by zero)."""
+        options = [{'option_type': 'PE', 'oi': 500}]
+        assert self.calc.calculate_pcr_from_options(options) is None
+
+    def test_from_options_no_puts(self):
+        """Only calls, no puts -> PCR = 0."""
+        options = [{'option_type': 'CE', 'oi': 500}]
+        assert self.calc.calculate_pcr_from_options(options) == 0.0
+
+
+class TestGetSentiment:
+    """Test sentiment classification from PCR."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_extreme_bearish(self):
+        assert self.calc.get_sentiment(2.0) == "EXTREME_BEARISH"
+        assert self.calc.get_sentiment(1.5) == "EXTREME_BEARISH"
+
+    def test_bearish(self):
+        assert self.calc.get_sentiment(1.2) == "BEARISH"
+        assert self.calc.get_sentiment(1.0) == "BEARISH"
+
+    def test_bullish(self):
+        assert self.calc.get_sentiment(0.7) == "BULLISH"
+
+    def test_extreme_bullish(self):
+        assert self.calc.get_sentiment(0.3) == "EXTREME_BULLISH"
+        assert self.calc.get_sentiment(0.5) == "EXTREME_BULLISH"
+
+    def test_none_pcr(self):
+        assert self.calc.get_sentiment(None) == "UNKNOWN"
+
+    def test_neutral_not_reachable(self):
+        """With BEARISH_THRESHOLD == BULLISH_THRESHOLD == 1.0, neutral requires pcr > 1.0 AND pcr < 1.0 (impossible).
+        Actually per code: pcr > 1.0 is BEARISH or EXTREME_BEARISH, pcr < 1.0 is BULLISH.
+        pcr == 1.0 falls into BEARISH. So NEUTRAL is never returned with equal thresholds."""
+        # PCR must be strictly > BULLISH_THRESHOLD (1.0) to not be BULLISH,
+        # but >= BEARISH_THRESHOLD (1.0) makes it BEARISH. So 1.0 is BEARISH.
+        assert self.calc.get_sentiment(1.0) == "BEARISH"
+
+
+class TestSignalChecks:
+    """Test bullish/bearish/extreme signal checks."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_is_bullish(self):
+        assert self.calc.is_bullish_signal(0.7) is True
+        assert self.calc.is_bullish_signal(1.0) is False
+        assert self.calc.is_bullish_signal(1.5) is False
+
+    def test_is_bearish(self):
+        assert self.calc.is_bearish_signal(1.5) is True
+        assert self.calc.is_bearish_signal(1.0) is False
+        assert self.calc.is_bearish_signal(0.5) is False
+
+    def test_is_extreme(self):
+        assert self.calc.is_extreme_signal(2.0) is True
+        assert self.calc.is_extreme_signal(0.3) is True
+        assert self.calc.is_extreme_signal(1.0) is False
+
+    def test_none_returns_false(self):
+        assert self.calc.is_bullish_signal(None) is False
+        assert self.calc.is_bearish_signal(None) is False
+        assert self.calc.is_extreme_signal(None) is False
+
+
+class TestPCRHistory:
+    """Test PCR recording and history."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_record_pcr(self):
+        self.calc.record_pcr(1.2, 1200, 1000)
+        assert len(self.calc.pcr_history) == 1
+        assert self.calc.pcr_history[0]['pcr'] == 1.2
+
+    def test_record_none_pcr_skipped(self):
+        self.calc.record_pcr(None, 0, 0)
+        assert len(self.calc.pcr_history) == 0
+
+    def test_max_history_trimmed(self):
+        for i in range(150):
+            self.calc.record_pcr(1.0 + i * 0.001, 1000, 1000)
+        assert len(self.calc.pcr_history) == 100
+
+    def test_get_pcr_history_limit(self):
+        for i in range(20):
+            self.calc.record_pcr(1.0, 1000, 1000)
+        assert len(self.calc.get_pcr_history(5)) == 5
+
+    def test_clear_history(self):
+        self.calc.record_pcr(1.0, 1000, 1000)
+        self.calc.clear_history()
+        assert len(self.calc.pcr_history) == 0
+
+
+class TestPCRTrend:
+    """Test PCR trend calculation."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_increasing_trend(self):
+        for pcr in [0.8, 0.9, 1.0, 1.1, 1.2]:
+            self.calc.record_pcr(pcr, 1000, 1000)
+        assert self.calc.get_pcr_trend(5) == "INCREASING"
+
+    def test_decreasing_trend(self):
+        for pcr in [1.2, 1.1, 1.0, 0.9, 0.8]:
+            self.calc.record_pcr(pcr, 1000, 1000)
+        assert self.calc.get_pcr_trend(5) == "DECREASING"
+
+    def test_stable_trend(self):
+        for _ in range(5):
+            self.calc.record_pcr(1.0, 1000, 1000)
+        assert self.calc.get_pcr_trend(5) == "STABLE"
+
+    def test_insufficient_data(self):
+        self.calc.record_pcr(1.0, 1000, 1000)
+        assert self.calc.get_pcr_trend(5) is None
+
+
+class TestPCRAnalysis:
+    """Test comprehensive PCR analysis."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_analysis_with_none_pcr(self):
+        result = self.calc.get_pcr_analysis(None, 0, 0)
+        assert result['sentiment'] == 'UNKNOWN'
+        assert result['is_bullish'] is False
+        assert result['is_bearish'] is False
+
+    def test_analysis_bearish(self):
+        result = self.calc.get_pcr_analysis(1.3, 1300, 1000)
+        assert result['sentiment'] == 'BEARISH'
+        assert result['is_bearish'] is True
+        assert result['is_bullish'] is False
+        assert result['pcr'] == 1.3
+
+    def test_analysis_bullish(self):
+        result = self.calc.get_pcr_analysis(0.7, 700, 1000)
+        assert result['sentiment'] == 'BULLISH'
+        assert result['is_bullish'] is True
+
+    def test_analysis_has_all_keys(self):
+        result = self.calc.get_pcr_analysis(1.0, 1000, 1000)
+        expected_keys = {'pcr', 'put_oi', 'call_oi', 'sentiment', 'emoji',
+                         'is_bullish', 'is_bearish', 'is_extreme', 'trend',
+                         'interpretation', 'timestamp'}
+        assert expected_keys == set(result.keys())
+
+
+class TestSentimentEmoji:
+    """Test emoji helper."""
+
+    def setup_method(self):
+        self.calc = PCRCalculator()
+
+    def test_known_sentiments(self):
+        assert self.calc.get_sentiment_emoji("BULLISH") == "\U0001f7e2"
+        assert self.calc.get_sentiment_emoji("BEARISH") == "\U0001f534"
+        assert self.calc.get_sentiment_emoji("UNKNOWN") == "\u2753"
+
+    def test_unknown_sentiment(self):
+        assert self.calc.get_sentiment_emoji("INVALID") == "\u2753"

--- a/backend/tests/test_position_manager.py
+++ b/backend/tests/test_position_manager.py
@@ -1,0 +1,194 @@
+"""Tests for Position and PositionManager."""
+
+import pytest
+import datetime
+from unittest.mock import patch
+from app.managers.position_manager import Position, PositionManager
+
+
+class TestPosition:
+    """Test Position dataclass-like object."""
+
+    def test_create_position(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE")
+        assert pos.instrument_key == "NSE_FO|12345"
+        assert pos.entry_price == 100.0
+        assert pos.quantity == 10
+        assert pos.position_type == "CE"
+        assert pos.id is not None
+
+    def test_stop_loss_calculation(self):
+        """Default SL is 30% below entry."""
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE", stop_loss_pct=0.30)
+        assert pos.stop_loss == 70.0
+
+    def test_target_calculation(self):
+        """Default target is 1.5x entry."""
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE", target_multiplier=1.5)
+        assert pos.target == 150.0
+
+    def test_to_dict(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE")
+        d = pos.to_dict()
+        assert d['instrument_key'] == "NSE_FO|12345"
+        assert d['entry_price'] == 100.0
+        assert d['quantity'] == 10
+        assert d['position_type'] == "CE"
+        assert 'id' in d
+        assert 'entry_time' in d
+
+
+class TestTrailingStop:
+    """Test trailing stop logic."""
+
+    def test_trailing_not_activated_below_threshold(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE",
+                       trailing_activation_pct=1.0, trailing_pct=0.5)
+        pos.update_trailing_stop(100.5)  # 0.5% gain, below 1% activation
+        assert pos.trailing_sl_activated is False
+        assert pos.trailing_sl is None
+
+    def test_trailing_activated_at_threshold(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE",
+                       trailing_activation_pct=1.0, trailing_pct=0.5)
+        pos.update_trailing_stop(101.0)  # 1% gain
+        assert pos.trailing_sl_activated is True
+        assert pos.trailing_sl is not None
+
+    def test_trailing_sl_moves_up(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE",
+                       trailing_activation_pct=1.0, trailing_pct=0.5)
+        pos.update_trailing_stop(102.0)
+        sl1 = pos.trailing_sl
+        pos.update_trailing_stop(105.0)
+        sl2 = pos.trailing_sl
+        assert sl2 > sl1
+
+    def test_trailing_sl_does_not_move_down(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE",
+                       trailing_activation_pct=1.0, trailing_pct=0.5)
+        pos.update_trailing_stop(105.0)
+        sl_high = pos.trailing_sl
+        pos.update_trailing_stop(103.0)
+        assert pos.trailing_sl == sl_high
+
+
+class TestShouldExit:
+    """Test exit conditions."""
+
+    def test_stop_loss_hit(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE", stop_loss_pct=0.30)
+        now = datetime.datetime(2025, 1, 1, 10, 0)
+        should, reason = pos.should_exit(69.0, now)
+        assert should is True
+        assert "STOP_LOSS" in reason
+
+    def test_target_hit(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE", target_multiplier=1.5)
+        now = datetime.datetime(2025, 1, 1, 10, 0)
+        should, reason = pos.should_exit(151.0, now)
+        assert should is True
+        assert "TARGET_HIT" in reason
+
+    def test_trailing_sl_hit(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE",
+                       trailing_activation_pct=1.0, trailing_pct=0.5)
+        now = datetime.datetime(2025, 1, 1, 10, 0)
+        # Activate trailing SL
+        pos.update_trailing_stop(110.0)
+        # Price drops below trailing SL
+        should, reason = pos.should_exit(pos.trailing_sl - 1, now)
+        assert should is True
+        assert "TRAILING_SL" in reason
+
+    def test_time_based_exit(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE")
+        close_time = datetime.datetime(2025, 1, 1, 15, 16)
+        should, reason = pos.should_exit(100.0, close_time)
+        assert should is True
+        assert "TIME_BASED_EXIT" in reason
+
+    def test_no_exit(self):
+        pos = Position("NSE_FO|12345", 100.0, 10, "CE", stop_loss_pct=0.30,
+                       target_multiplier=1.5)
+        now = datetime.datetime(2025, 1, 1, 10, 0)
+        should, reason = pos.should_exit(100.0, now)
+        assert should is False
+        assert reason == ""
+
+
+class TestPositionManager:
+    """Test PositionManager CRUD operations."""
+
+    def test_open_position(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        pos = pm.open_position("NSE_FO|12345", 100.0, 10, "CE")
+        assert pos.entry_price == 100.0
+        assert pm.get_position_count() == 1
+
+    def test_close_position(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        pos = pm.open_position("NSE_FO|12345", 100.0, 10, "CE")
+        trade = pm.close_position(pos.id, 120.0, "TARGET")
+        assert trade is not None
+        assert trade['pnl'] == 200.0  # (120-100) * 10
+        assert pm.get_position_count() == 0
+
+    def test_close_nonexistent_position(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        assert pm.close_position("fake-id", 100, "TEST") is None
+
+    def test_invalid_instrument_key(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        with pytest.raises(ValueError, match="Invalid instrument_key"):
+            pm.open_position("INVALID", 100.0, 10, "CE")
+
+    def test_valid_instrument_keys(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        assert pm._is_valid_instrument_key("NSE_FO|12345") is True
+        assert pm._is_valid_instrument_key("NSE_INDEX|Nifty 50") is True
+        assert pm._is_valid_instrument_key("NSE_EQ|RELIANCE") is True
+
+    def test_invalid_instrument_keys(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        assert pm._is_valid_instrument_key("") is False
+        assert pm._is_valid_instrument_key("INVALID") is False
+        assert pm._is_valid_instrument_key("BSE_FO|123") is False
+        assert pm._is_valid_instrument_key("NSE_FO|") is False
+        assert pm._is_valid_instrument_key(None) is False
+
+    def test_get_positions(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        pm.open_position("NSE_FO|11111", 100.0, 5, "CE")
+        pm.open_position("NSE_FO|22222", 200.0, 3, "PE")
+        positions = pm.get_positions()
+        assert len(positions) == 2
+
+    def test_unrealized_pnl(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        pos = pm.open_position("NSE_FO|12345", 100.0, 10, "CE")
+        pnl = pm.calculate_unrealized_pnl({"NSE_FO|12345": 110.0})
+        assert pnl == 100.0  # (110-100) * 10
+
+    def test_unrealized_pnl_missing_price(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        pm.open_position("NSE_FO|12345", 100.0, 10, "CE")
+        pnl = pm.calculate_unrealized_pnl({})
+        assert pnl == 0.0
+
+    def test_check_exits_stop_loss(self, tmp_json_file):
+        pm = PositionManager(data_file=tmp_json_file)
+        pos = pm.open_position("NSE_FO|12345", 100.0, 10, "CE")
+        # SL is at 70.0 (30% default)
+        closed = pm.check_exits({"NSE_FO|12345": 65.0})
+        assert len(closed) == 1
+        assert "STOP_LOSS" in closed[0]['reason']
+        assert pm.get_position_count() == 0
+
+    def test_persistence(self, tmp_json_file):
+        """Positions should persist to file and be reloadable."""
+        pm1 = PositionManager(data_file=tmp_json_file)
+        pm1.open_position("NSE_FO|12345", 100.0, 10, "CE")
+
+        pm2 = PositionManager(data_file=tmp_json_file)
+        assert pm2.get_position_count() == 1

--- a/backend/tests/test_risk_manager.py
+++ b/backend/tests/test_risk_manager.py
@@ -1,0 +1,138 @@
+"""Tests for Risk Manager."""
+
+import pytest
+import datetime
+from unittest.mock import patch
+from app.managers.risk_manager import RiskManager
+
+
+class TestRiskManagerInit:
+
+    def test_default_params(self):
+        rm = RiskManager()
+        assert rm.initial_capital == 100000
+        assert rm.risk_per_trade_pct == 0.02
+        assert rm.daily_loss_limit_pct == 0.05
+        assert rm.max_concurrent_positions == 2
+
+    def test_custom_params(self):
+        rm = RiskManager(initial_capital=500000, risk_per_trade_pct=0.01,
+                         daily_loss_limit_pct=0.03, max_concurrent_positions=5)
+        assert rm.initial_capital == 500000
+        assert rm.risk_per_trade_pct == 0.01
+        assert rm.daily_loss_limit_pct == 0.03
+        assert rm.max_concurrent_positions == 5
+
+    def test_daily_pnl_starts_zero(self):
+        rm = RiskManager()
+        assert rm.daily_pnl == 0.0
+
+
+class TestCanTrade:
+
+    def setup_method(self):
+        self.rm = RiskManager(initial_capital=100000, daily_loss_limit_pct=0.05,
+                              max_concurrent_positions=2)
+
+    def test_can_trade_ok(self):
+        can, reason = self.rm.can_trade(50000, 0)
+        assert can is True
+        assert reason == "OK"
+
+    def test_daily_loss_limit_blocks(self):
+        """After losing more than 5% of capital, trading should be blocked."""
+        self.rm.daily_pnl = -6000  # > 5% of 100000
+        can, reason = self.rm.can_trade(94000, 0)
+        assert can is False
+        assert "Daily loss limit" in reason
+
+    def test_max_positions_blocks(self):
+        can, reason = self.rm.can_trade(50000, 2)
+        assert can is False
+        assert "Max concurrent positions" in reason
+
+    def test_zero_balance_blocks(self):
+        can, reason = self.rm.can_trade(0, 0)
+        assert can is False
+        assert "Insufficient balance" in reason
+
+    def test_negative_balance_blocks(self):
+        can, reason = self.rm.can_trade(-100, 0)
+        assert can is False
+        assert "Insufficient balance" in reason
+
+
+class TestPositionSize:
+
+    def setup_method(self):
+        self.rm = RiskManager(initial_capital=100000, risk_per_trade_pct=0.02)
+
+    def test_basic_position_size(self):
+        """Risk amount = 100000 * 0.02 = 2000. Risk per unit = 100 * 0.30 = 30.
+        Max qty = 2000 / 30 = 66."""
+        qty = self.rm.calculate_position_size(100, 0.30, 100000)
+        assert qty == 66
+
+    def test_minimum_is_one(self):
+        """Even with low balance, minimum is 1."""
+        qty = self.rm.calculate_position_size(1000, 0.30, 100)
+        assert qty == 1
+
+    def test_max_is_100(self):
+        """Max capped at 100."""
+        qty = self.rm.calculate_position_size(1, 0.01, 1000000)
+        assert qty == 100
+
+    def test_zero_stop_loss_returns_zero(self):
+        qty = self.rm.calculate_position_size(100, 0, 100000)
+        assert qty == 0
+
+    def test_zero_entry_price(self):
+        qty = self.rm.calculate_position_size(0, 0.30, 100000)
+        assert qty == 0
+
+
+class TestDailyPnl:
+
+    def setup_method(self):
+        self.rm = RiskManager()
+
+    def test_update_daily_pnl(self):
+        self.rm.update_daily_pnl(500)
+        assert self.rm.daily_pnl == 500
+
+    def test_accumulate_pnl(self):
+        self.rm.update_daily_pnl(500)
+        self.rm.update_daily_pnl(-200)
+        assert self.rm.daily_pnl == 300
+
+    @patch('app.managers.risk_manager.datetime')
+    def test_auto_reset_on_new_day(self, mock_dt):
+        """PnL should reset when a new day starts."""
+        self.rm.daily_pnl = -1000
+        self.rm.last_reset_date = datetime.date(2025, 1, 1)
+        mock_dt.date.today.return_value = datetime.date(2025, 1, 2)
+        self.rm.reset_daily_stats()
+        assert self.rm.daily_pnl == 0.0
+
+
+class TestGetStats:
+
+    def test_stats_keys(self):
+        rm = RiskManager()
+        stats = rm.get_stats()
+        expected_keys = {"daily_pnl", "daily_loss_limit", "risk_per_trade_pct",
+                         "max_concurrent_positions", "is_trading_allowed"}
+        assert set(stats.keys()) == expected_keys
+
+    def test_stats_values(self):
+        rm = RiskManager(initial_capital=100000, daily_loss_limit_pct=0.05)
+        stats = rm.get_stats()
+        assert stats['daily_loss_limit'] == 5000.0
+        assert stats['is_trading_allowed'] is True
+
+    def test_trading_not_allowed_after_loss(self):
+        rm = RiskManager(initial_capital=100000, daily_loss_limit_pct=0.05)
+        rm.daily_pnl = -6000
+        stats = rm.get_stats()
+        assert stats['is_trading_allowed'] is False

--- a/backend/tests/test_strategy.py
+++ b/backend/tests/test_strategy.py
@@ -1,0 +1,250 @@
+"""Tests for Strategy Engine - technical indicators and signal generation."""
+
+import pytest
+import pandas as pd
+import numpy as np
+from app.strategies.strategy import StrategyEngine
+
+
+class TestCalculateRSI:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_rsi_range(self, sample_ohlcv_df):
+        rsi = self.engine.calculate_rsi(sample_ohlcv_df['close'])
+        valid = rsi.dropna()
+        assert (valid >= 0).all()
+        assert (valid <= 100).all()
+
+    def test_rsi_uptrend_high(self):
+        """Consistently rising prices should produce RSI near 100."""
+        prices = pd.Series(range(100, 200))
+        rsi = self.engine.calculate_rsi(prices)
+        assert rsi.iloc[-1] > 80
+
+    def test_rsi_downtrend_low(self):
+        """Consistently falling prices should produce RSI near 0."""
+        prices = pd.Series(range(200, 100, -1))
+        rsi = self.engine.calculate_rsi(prices)
+        assert rsi.iloc[-1] < 20
+
+    def test_rsi_custom_period(self):
+        prices = pd.Series(range(100, 200))
+        rsi = self.engine.calculate_rsi(prices, period=7)
+        valid = rsi.dropna()
+        assert len(valid) > 0
+
+
+class TestCalculateEMA:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_ema_length(self, sample_ohlcv_df):
+        ema = self.engine.calculate_ema(sample_ohlcv_df['close'], 20)
+        assert len(ema) == len(sample_ohlcv_df)
+
+    def test_ema_converges_to_price(self):
+        """EMA of a constant series should equal the constant."""
+        series = pd.Series([100.0] * 50)
+        ema = self.engine.calculate_ema(series, 10)
+        assert pytest.approx(ema.iloc[-1], abs=0.01) == 100.0
+
+    def test_short_ema_reacts_faster(self, sample_ohlcv_df):
+        """Short period EMA should track price more closely."""
+        close = sample_ohlcv_df['close']
+        ema_5 = self.engine.calculate_ema(close, 5)
+        ema_20 = self.engine.calculate_ema(close, 20)
+        # Short EMA should be closer to the last price
+        last_price = close.iloc[-1]
+        assert abs(ema_5.iloc[-1] - last_price) <= abs(ema_20.iloc[-1] - last_price)
+
+
+class TestCalculateMACD:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_macd_returns_two_series(self, sample_ohlcv_df):
+        macd, signal = self.engine.calculate_macd(sample_ohlcv_df['close'])
+        assert len(macd) == len(sample_ohlcv_df)
+        assert len(signal) == len(sample_ohlcv_df)
+
+    def test_macd_constant_price_is_zero(self):
+        """MACD of constant price should be ~0."""
+        series = pd.Series([100.0] * 100)
+        macd, signal = self.engine.calculate_macd(series)
+        assert pytest.approx(macd.iloc[-1], abs=0.01) == 0
+
+
+class TestCalculateBollingerBands:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_upper_above_lower(self, sample_ohlcv_df):
+        upper, lower = self.engine.calculate_bollinger_bands(sample_ohlcv_df['close'])
+        valid = upper.dropna() > lower.dropna()
+        assert valid.all()
+
+    def test_bands_around_sma(self, sample_ohlcv_df):
+        close = sample_ohlcv_df['close']
+        upper, lower = self.engine.calculate_bollinger_bands(close, period=20, std_dev=2)
+        sma = close.rolling(20).mean()
+        # Upper should be above SMA and lower below
+        valid_idx = sma.dropna().index
+        assert (upper[valid_idx] >= sma[valid_idx]).all()
+        assert (lower[valid_idx] <= sma[valid_idx]).all()
+
+
+class TestCalculateSupertrend:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_returns_three_series(self, sample_ohlcv_df):
+        trend, upper, lower = self.engine.calculate_supertrend(sample_ohlcv_df)
+        assert len(trend) == len(sample_ohlcv_df)
+        assert len(upper) == len(sample_ohlcv_df)
+        assert len(lower) == len(sample_ohlcv_df)
+
+    def test_trend_is_boolean(self, sample_ohlcv_df):
+        trend, _, _ = self.engine.calculate_supertrend(sample_ohlcv_df)
+        for val in trend:
+            assert val in (True, False)
+
+
+class TestCalculateVWAP:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_vwap_no_nans(self, sample_ohlcv_df):
+        vwap = self.engine.calculate_vwap(sample_ohlcv_df)
+        assert not vwap.isna().any()
+
+    def test_vwap_within_price_range(self, sample_ohlcv_df):
+        vwap = self.engine.calculate_vwap(sample_ohlcv_df)
+        # VWAP should be within the overall high-low range
+        overall_high = sample_ohlcv_df['high'].max()
+        overall_low = sample_ohlcv_df['low'].min()
+        assert vwap.iloc[-1] >= overall_low * 0.95
+        assert vwap.iloc[-1] <= overall_high * 1.05
+
+
+class TestCalculateATR:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_atr_positive(self, sample_ohlcv_df):
+        atr = self.engine.calculate_atr(sample_ohlcv_df)
+        valid = atr.dropna()
+        assert (valid >= 0).all()
+
+
+class TestDetectBreakout:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_no_breakout_normal_data(self, sample_ohlcv_df):
+        result = self.engine.detect_breakout(sample_ohlcv_df)
+        assert 'is_breakout' in result
+        assert 'breakout_type' in result
+
+    def test_insufficient_data(self, small_ohlcv_df):
+        result = self.engine.detect_breakout(small_ohlcv_df)
+        assert result['is_breakout'] is False
+
+    def test_upside_breakout(self):
+        """Create data where close exceeds highest_high * (1+sensitivity).
+        detect_breakout uses last 50 highs (including current candle) for threshold,
+        so set high of the last candle at same level as others so threshold stays low,
+        but close spikes above the threshold."""
+        n = 60
+        prices = np.full(n, 100.0)
+        highs = np.full(n, 100.1)
+        lows = np.full(n, 99.9)
+        # Close spikes well above highest_high threshold: 100.1 * 1.015 = ~101.6
+        prices[-1] = 105.0
+        df = pd.DataFrame({
+            'open': prices,
+            'high': highs,
+            'low': lows,
+            'close': prices,
+            'volume': [1000] * n
+        })
+        result = self.engine.detect_breakout(df, sensitivity=0.015)
+        assert result['is_breakout'] is True
+        assert result['breakout_type'] == "UPSIDE"
+
+
+class TestCalculateSupportResistance:
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_returns_expected_keys(self, sample_ohlcv_df):
+        result = self.engine.calculate_support_resistance(sample_ohlcv_df)
+        assert 'support_levels' in result
+        assert 'resistance_levels' in result
+        assert 'nearest_support' in result
+        assert 'nearest_resistance' in result
+        assert 'current_price' in result
+
+
+class TestCheckSignal:
+    """Test the main signal generation."""
+
+    def setup_method(self):
+        self.engine = StrategyEngine()
+
+    def test_waiting_data_for_none(self):
+        assert self.engine.check_signal(None) == "WAITING_DATA"
+
+    def test_waiting_data_for_empty(self):
+        assert self.engine.check_signal(pd.DataFrame()) == "WAITING_DATA"
+
+    def test_waiting_data_for_small(self, small_ohlcv_df):
+        assert self.engine.check_signal(small_ohlcv_df) == "WAITING_DATA"
+
+    def test_returns_dict_with_signal(self, sample_ohlcv_df):
+        result = self.engine.check_signal(sample_ohlcv_df)
+        assert isinstance(result, dict)
+        assert 'signal' in result
+        assert result['signal'] in ("BUY_CE", "BUY_PE", "HOLD")
+
+    def test_result_has_all_keys(self, sample_ohlcv_df):
+        result = self.engine.check_signal(sample_ohlcv_df)
+        expected_keys = {'signal', 'reason', 'rsi', 'supertrend', 'ema_5', 'ema_20',
+                         'vwap', 'pcr', 'greeks', 'support_resistance', 'breakout',
+                         'filters', 'volume_ratio', 'atr_pct'}
+        assert expected_keys.issubset(set(result.keys()))
+
+    def test_filters_dict_present(self, sample_ohlcv_df):
+        result = self.engine.check_signal(sample_ohlcv_df)
+        filters = result['filters']
+        expected = {'supertrend', 'ema_crossover', 'price_vwap', 'rsi',
+                    'volume', 'volatility', 'pcr', 'greeks', 'entry_confirmation'}
+        assert expected == set(filters.keys())
+
+    def test_backtest_mode_skips_pcr_greeks(self, sample_ohlcv_df):
+        result = self.engine.check_signal(sample_ohlcv_df, pcr=None, greeks=None,
+                                          backtest_mode=True)
+        assert result['filters']['pcr'] is True
+        assert result['filters']['greeks'] is True
+
+    def test_rsi_in_valid_range(self, sample_ohlcv_df):
+        result = self.engine.check_signal(sample_ohlcv_df)
+        if result['rsi'] is not None:
+            assert 0 <= result['rsi'] <= 100
+
+    def test_no_nan_in_output(self, sample_ohlcv_df):
+        """Output should have no NaN values (sanitized)."""
+        result = self.engine.check_signal(sample_ohlcv_df)
+        for key in ['rsi', 'ema_5', 'ema_20', 'vwap', 'atr_pct']:
+            val = result[key]
+            if val is not None:
+                assert not np.isnan(val), f"{key} is NaN"


### PR DESCRIPTION
## Summary
- Adds pytest infrastructure (`pytest.ini`, `conftest.py` with shared fixtures)
- Adds **225 tests** across 9 test files covering all core modules:
  - `test_greeks.py` — Black-Scholes d1/d2, Greeks (delta/gamma/theta/vega/rho), option pricing, put-call parity, implied volatility, quality scoring
  - `test_pcr_calculator.py` — PCR calculation, sentiment classification, signal checks, history/trend tracking, analysis
  - `test_greeks_validator.py` — Delta/gamma/theta/vega/rho/IV validation, relationship checks, quality scoring
  - `test_strategy.py` — RSI, EMA, MACD, Bollinger Bands, Supertrend, VWAP, ATR, breakout detection, support/resistance, signal generation
  - `test_risk_manager.py` — Position sizing, daily loss limits, concurrent position limits, daily P&L tracking
  - `test_position_manager.py` — Position creation, trailing stops, exit conditions, persistence, instrument validation
  - `test_paper_trading.py` — Order simulation, balance management, position averaging, P&L (realized/unrealized)
  - `test_backtester.py` — Metrics calculation, mock data generation, backtest pipeline
  - `test_json_utils.py` — Numpy type conversion for JSON serialization
- Fixes `.gitignore` to stop ignoring test files in `backend/tests/`

## Test plan
- [x] All 225 tests pass (`python3 -m pytest tests/ -v`)
- [ ] Verify tests run in CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)